### PR TITLE
add the ability to make a new version on an existing doi

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ I think this is kind of silly, but that's just me.
 
 ## Usage
 
+This action runs in 2 variants. By default it'll create a unique DOI every single time.
+However, If you specify `doi` in the action, it will create *new versions* of that existing
+DOI.  These are essentially new DOIs, but they're associated in Zenodo with this base `doi`.
+
 ### GitHub Action
 
 After you complete the steps above to create the metadata file, you might create a release
@@ -70,6 +74,14 @@ jobs:
         version: ${{ github.event.release.tag_name }}
         zenodo_json: .zenodo.json
         archive: ${{ env.archive }}
+
+        # Optional DOI to create a new version from. Leaving this blank (the default) will create
+        # a new DOI on every release. Use this if you have an existing DOI to use
+        # as a base and this action will create new versions of it.
+        #
+        # Newer versions have their own DOIs, but they're also linked to this DOI
+        # as a different version.
+        doi: '10.5281/zenodo.6326823'
 ```
 
 Notice how we are choosing to use the .tar.gz (you could use the zip too at `${{ github.event.release.zipball_url }}`)

--- a/action.yml
+++ b/action.yml
@@ -54,5 +54,6 @@ runs:
         version: ${{ inputs.version }}
         ACTION_PATH: ${{ github.action_path }}
         ZENODO_TOKEN: ${{ inputs.token }}
-      run: python ${{ github.action_path }}/scripts/deploy.py upload ${archive} --zenodo-json ${zenodo_json} --version ${version}
+        doi: ${{ inputs.doi }}
+      run: python ${{ github.action_path }}/scripts/deploy.py upload ${archive} --zenodo-json ${zenodo_json} --version ${version} --doi ${doi}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     required: true
   zenodo_json:
     description: Path to zenodo.json to upload with metadata (must exist)
+  doi:
+    descripton: The DOI to create a new version from
 
 outputs:
   badge:

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -60,7 +60,7 @@ def upload_archive(archive, zenodo_json, version, doi=None):
         if not target_deposit:
             sys.exit("Cannot find deposit with doi: '%s'. Are you currently editing it?" % (doi))
 
-        # found the existing deposit - so let's make a new version and clean it up.
+        # found the existing deposit - so let's make a new version.
         url = "%s/actions/newversion" % target_deposit['links']['self']
         new_version = requests.post(
             url,
@@ -79,6 +79,8 @@ def upload_archive(archive, zenodo_json, version, doi=None):
         if new_version.status_code not in [200, 201]:
             sys.exit("Cannot create a new version for doi '%s'. %s" % (doi, new_version.json()))
 
+        # this draft is based off of version N-1, so let's remove N-1's artifacts to make room
+        # for version N.
         for file in new_version.json()['files']:
             delete = requests.delete(
                 file['links']['self'],

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -54,6 +54,7 @@ def upload_archive(archive, zenodo_json, version, doi=None):
 
         target_deposit = None
         for deposit in depositions.json():
+            print("looking at deposit %s" % (deposit['doi']))
             if deposit['doi'] == doi:
                 target_deposit = deposit
 


### PR DESCRIPTION
Fixes #1.

I ran out of time today to update the README and test that creating brand new DOIs still work. Indeed - because I don't now much about GH action internals, I don't know if the `action.yml` is correct (for example `doi` being optional).

In any case - I don't work after hours or on the weekend so I'll pick this back up on Monday.  I'd be happy to refactor it a bit so maybe all that stuff is in a separate function and so on (and/or change anything, I'm not super strong in python)?  Either way - I'll see comments then.

This is what I'd been testing with
```
#!/bin/bash

VERSION='2.0.0'
JSON="/home/jeff/ondemand/misc/test-actions/.zenodo.json"

python3 scripts/deploy.py upload --zenodo-json $JSON --version $VERSION "$VERSION.zip" --doi '10.5281/zenodo.6323748'
```