### PR TITLE
metadata improvemens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .env
+.vscode
+.idea
+.run

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ jobs:
         zenodo_json: .zenodo.json   # optional
         html_url: ${{ github.event.release.html_url }} # optional to include link to the GitHub release
         archive: ${{ env.archive }}
+        title: ${{ github.repository }}:${{ github.event.release.tag_name }}  # optional title to override
+        description: <h1>${{ github.event.release.tag_name }}</h1>  # optional release description (allows HTML)
 
         # Optional DOI for all versions. Leaving this blank (the default) will create
         # a new DOI on every release. Use a DOI that represents all versions will
@@ -207,4 +209,3 @@ export ZENODO_TOKEN=xxxxxxxxxxxxxxxxxxxx
                                   # archive    # multi-version DOI                 # new version
 $ python scripts/deploy.py upload 0.0.0.tar.gz --doi 10.5281/zenodo.6326822        --version 0.0.0
 ```
-

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
     description: Path to zenodo.json to upload with metadata (must exist)
   doi:
     descripton: The DOI to create a new version from
+  title:
+    description: zenodo title (optional)
+  description:
+    description: zenodo description (optional)
 
 outputs:
   badge:

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -255,8 +255,7 @@ class Zenodo:
         )
         if response.status_code != 200:
             sys.exit(
-                "Trouble uploading metadata %s, %s" % response.status_code,
-                response.json(),
+                "Trouble uploading metadata %s, %s" % (response.status_code, response.json())
             )
         return response.json()
 


### PR DESCRIPTION
- adds `title` override option
- adds `description` override option (which allows injecting a nice HTML rendering about the record to be generated)
- avoids completely overriding `related_identifiers` if some were already provided in `.zenodo.json`